### PR TITLE
Set the mAnimationReadyTime for debug builds

### DIFF
--- a/gfx/layers/wr/WebrenderLayerManager.cpp
+++ b/gfx/layers/wr/WebrenderLayerManager.cpp
@@ -104,6 +104,9 @@ WebRenderLayerManager::EndTransaction(DrawPaintedLayerCallback aCallback,
       wr_delete_image(mWRState, key);
   }
   mImageKeys.clear();
+
+  // Since we don't do repeat transactions right now, just set the time
+  mAnimationReadyTime = TimeStamp::Now();
 }
 
 void


### PR DESCRIPTION
Otherwise we'd hit this assert - http://searchfox.org/mozilla-central/source/layout/base/nsDisplayList.cpp#1712

The current ClientLayerManager only updates it on non-repeat transactions - http://searchfox.org/mozilla-central/source/gfx/layers/client/ClientLayerManager.cpp#324
