### PR TITLE
Export update_image() for video usage.

### DIFF
--- a/gfx/webrender/src/bindings.rs
+++ b/gfx/webrender/src/bindings.rs
@@ -308,6 +308,12 @@ pub extern fn wr_add_image(state:&mut WrState, width: u32, height: u32, format: 
 }
 
 #[no_mangle]
+pub extern fn wr_update_image(state:&mut WrState, key: ImageKey, width: u32, height: u32, format: ImageFormat, bytes: * const u8, size: usize) {
+    let bytes = unsafe { slice::from_raw_parts(bytes, size).to_owned() };
+    state.api.update_image(key, width, height, format, bytes);
+}
+
+#[no_mangle]
 pub extern fn wr_delete_image(state:&mut WrState, key: ImageKey) {
     state.api.delete_image(key)
 }

--- a/gfx/webrender/webrender.h
+++ b/gfx/webrender/webrender.h
@@ -33,6 +33,9 @@ wrstate* wr_create(uint32_t width, uint32_t height, uint32_t counter);
 void wr_destroy(wrstate* wrstate);
 WRImageKey wr_add_image(wrstate* wrstate, uint32_t width, uint32_t height,
                         WRImageFormat format, uint8_t *bytes, size_t size);
+void wr_update_image(wrstate* wrstate, WRImageKey key,
+                     uint32_t width, uint32_t height,
+                     WRImageFormat format, uint8_t *bytes, size_t size);
 void wr_delete_image(wrstate* wrstate, WRImageKey key);
 
 void wr_push_dl_builder(wrstate *wrState);


### PR DESCRIPTION
In video case, we might try to bind a new video frame to an exist imageKey.
