### PR TITLE
Fix incorrect widget size with WebRender on linux.

### DIFF
--- a/gfx/layers/wr/WebrenderLayerManager.cpp
+++ b/gfx/layers/wr/WebrenderLayerManager.cpp
@@ -43,6 +43,12 @@ WebRenderLayerManager::~WebRenderLayerManager()
 
 }
 
+widget::CompositorWidgetDelegate*
+WebRenderLayerManager::GetCompositorWidgetDelegate()
+{
+  return mWidget->AsDelegate();
+}
+
 int32_t
 WebRenderLayerManager::GetMaxTextureSize() const
 {
@@ -88,7 +94,7 @@ WebRenderLayerManager::EndTransaction(DrawPaintedLayerCallback aCallback,
 
   mWidget->PreRender(this);
   mGLContext->MakeCurrent();
-  printf("WR Beginning\n");
+  printf("WR Beginning size %i %i\n", size.width, size.height);
   wr_dp_begin(mWRState, size.width, size.height);
 
   WebRenderLayer::ToWebRenderLayer(mRoot)->RenderLayer(mWRState);

--- a/gfx/layers/wr/WebrenderLayerManager.h
+++ b/gfx/layers/wr/WebrenderLayerManager.h
@@ -18,6 +18,7 @@ class GLContext;
 }
 namespace widget {
 class CompositorWidget;
+class CompositorWidgetDelegate;
 }
 namespace layers {
 
@@ -84,6 +85,8 @@ public:
   virtual already_AddRefed<RefLayer> CreateRefLayer() override;
 
   virtual bool NeedsWidgetInvalidation() override { return true; }
+
+  widget::CompositorWidgetDelegate* GetCompositorWidgetDelegate();
 
   DrawPaintedLayerCallback GetPaintedLayerCallback() const
   { return mPaintedLayerCallback; }

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -4497,6 +4497,12 @@ pref("network.tcp.keepalive.retry_interval", 1); // seconds
 pref("network.tcp.keepalive.probe_count", 4);
 #endif
 
+// disable e10s for now
+// TODO: fix WebRender + e10s!
+pref("browser.tabs.remote.autostart", false);
+pref("browser.tabs.remote.autostart.1", false);
+pref("browser.tabs.remote.autostart.2", false);
+
 // Whether to disable acceleration for all widgets.
 pref("layers.acceleration.disabled", false);
 // Preference that when switched at runtime will run a series of benchmarks

--- a/widget/nsBaseWidget.cpp
+++ b/widget/nsBaseWidget.cpp
@@ -1388,7 +1388,9 @@ LayerManager* nsBaseWidget::GetLayerManager(PLayerTransactionChild* aShadowManag
     }
 
     if (!XRE_IsContentProcess()) {
-      mLayerManager = new WebRenderLayerManager(this);
+      WebRenderLayerManager* manager = new WebRenderLayerManager(this);
+      mCompositorWidgetDelegate = manager->GetCompositorWidgetDelegate();
+      mLayerManager = manager;
     }
 
     // Try to use an async compositor first, if possible


### PR DESCRIPTION
the widget's CompositorWidgetDelegate is used to forward widget resize events on linux, and is set in nsBaseWidget::CreateCompositor. With WR we need to set it as well (it is created in WebRenderLayerManager but not passed to the nsBaseWidget).

With this we can get things to render on linux (glitchy, but better than a white window).
