### PR TITLE
Hook up APZ's compositor interface to WebRenderLayerManager

### DIFF
--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -91,6 +91,7 @@
 #endif
 
 #include "LayerScope.h"
+#include "WebrenderLayerManager.h"
 
 namespace mozilla {
 
@@ -222,7 +223,7 @@ CompositorBridgeParent::LayerTreeState::~LayerTreeState()
 }
 
 typedef map<uint64_t, CompositorBridgeParent::LayerTreeState> LayerTreeMap;
-static LayerTreeMap sIndirectLayerTrees;
+LayerTreeMap sIndirectLayerTrees;
 static StaticAutoPtr<mozilla::Monitor> sIndirectLayerTreesLock;
 
 static void EnsureLayerTreeMapReady()
@@ -2291,6 +2292,9 @@ private:
 CompositorController*
 CompositorBridgeParent::LayerTreeState::GetCompositorController() const
 {
+  if (mWRManager) {
+    return mWRManager;
+  }
   return mParent;
 }
 

--- a/gfx/layers/ipc/CompositorBridgeParent.h
+++ b/gfx/layers/ipc/CompositorBridgeParent.h
@@ -69,6 +69,7 @@ class PAPZParent;
 class CrossProcessCompositorBridgeParent;
 class CompositorThreadHolder;
 class InProcessCompositorSession;
+class WebRenderLayerManager;
 
 struct ScopedLayerTreeRegistration
 {
@@ -465,6 +466,7 @@ public:
     APZCTreeManagerParent* mApzcTreeManagerParent;
     CompositorBridgeParent* mParent;
     LayerManagerComposite* mLayerManager;
+    WebRenderLayerManager* mWRManager;
     // Pointer to the CrossProcessCompositorBridgeParent. Used by APZCs to share
     // their FrameMetrics with the corresponding child process that holds
     // the PCompositorBridgeChild

--- a/gfx/layers/wr/WebrenderLayerManager.h
+++ b/gfx/layers/wr/WebrenderLayerManager.h
@@ -69,6 +69,7 @@ public:
   virtual void EndTransaction(DrawPaintedLayerCallback aCallback,
                               void* aCallbackData,
                               EndTransactionFlags aFlags = END_DEFAULT) override;
+  virtual void Composite() override;
 
   virtual LayersBackend GetBackendType() override { return LayersBackend::LAYERS_WR; }
   virtual void GetBackendName(nsAString& name) override { name.AssignLiteral("WebRender"); }
@@ -94,9 +95,10 @@ public:
   void* GetPaintedLayerCallbackData() const
   { return mPaintedLayerCallbackData; }
 
-  // adds an imagekey to a list of keys that will be discarded at the end of
-  // the frame
+  // adds an imagekey to a list of keys that will be discarded on the next
+  // transaction or destruction
   void AddImageKeyForDiscard(WRImageKey);
+  void DiscardImages();
 
 private:
   RefPtr<widget::CompositorWidget> mWidget;

--- a/gfx/webrender/src/bindings.rs
+++ b/gfx/webrender/src/bindings.rs
@@ -370,6 +370,15 @@ pub extern fn wr_dp_end(state:&mut WrState) {
 }
 
 #[no_mangle]
+pub extern fn wr_composite(state: &mut WrState) {
+    state.api.generate_frame();
+
+    state.renderer.update();
+    let (width, height) = state.size;
+    state.renderer.render(Size2D::new(width, height));
+}
+
+#[no_mangle]
 pub extern fn wr_add_image(state:&mut WrState, width: u32, height: u32, format: ImageFormat, bytes: * const u8, size: usize) -> ImageKey {
     let bytes = unsafe { slice::from_raw_parts(bytes, size).to_owned() };
     state.api.add_image(width, height, format, bytes)

--- a/gfx/webrender/src/render_backend.rs
+++ b/gfx/webrender/src/render_backend.rs
@@ -256,6 +256,12 @@ impl RenderBackend {
 
                             self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
                         }
+                        ApiMsg::GenerateFrame => {
+                            let frame = profile_counters.total_time.profile(|| {
+                                self.render()
+                            });
+                            self.publish_frame_and_notify_compositor(frame, &mut profile_counters);
+                        }
                         ApiMsg::TranslatePointToLayerSpace(..) => {
                             panic!("unused api - remove from webrender_traits");
                         }

--- a/gfx/webrender/webrender.h
+++ b/gfx/webrender/webrender.h
@@ -43,6 +43,7 @@ void wr_push_dl_builder(wrstate *wrState);
 void wr_pop_dl_builder(wrstate *wrState, float x, float y, float width, float height, float *matrix);
 void wr_dp_begin(wrstate* wrState, uint32_t width, uint32_t height);
 void wr_dp_end(wrstate* wrState);
+void wr_composite(wrstate* wrState);
 void wr_dp_push_rect(wrstate* wrState, float x, float y, float w, float h, float r, float g, float b, float a);
 void wr_dp_push_image(wrstate* wrState, WRRect bounds, WRRect clip, WRImageKey key);
 

--- a/gfx/webrender_traits/src/api.rs
+++ b/gfx/webrender_traits/src/api.rs
@@ -205,6 +205,11 @@ impl RenderApi {
         self.api_sender.send(msg).unwrap();
     }
 
+    pub fn generate_frame(&self) {
+        let msg = ApiMsg::GenerateFrame;
+        self.api_sender.send(msg).unwrap();
+    }
+
     /// Translates a point from viewport coordinates to layer space
     pub fn translate_point_to_layer_space(&self, point: &Point2D<f32>)
                                           -> (Point2D<f32>, PipelineId) {

--- a/gfx/webrender_traits/src/types.rs
+++ b/gfx/webrender_traits/src/types.rs
@@ -52,6 +52,7 @@ pub enum ApiMsg {
     SetRootPipeline(PipelineId),
     Scroll(Point2D<f32>, Point2D<f32>, ScrollEventPhase),
     TickScrollingBounce,
+    GenerateFrame,
     TranslatePointToLayerSpace(Point2D<f32>, IpcSender<(Point2D<f32>, PipelineId)>),
     GetScrollLayerState(IpcSender<Vec<ScrollLayerState>>),
     RequestWebGLContext(Size2D<i32>, GLContextAttributes, IpcSender<Result<(WebGLContextId, GLLimits), String>>),

--- a/widget/nsBaseWidget.cpp
+++ b/widget/nsBaseWidget.cpp
@@ -1406,7 +1406,8 @@ LayerManager* nsBaseWidget::GetLayerManager(PLayerTransactionChild* aShadowManag
 
     if (!XRE_IsContentProcess()) {
       mRootLayerTreeId = Some(gfx::GPUProcessManager::Get()->AllocateLayerTreeId());
-      WebRenderLayerManager* manager = new WebRenderLayerManager(this);
+      WebRenderLayerManager* manager = new WebRenderLayerManager(this,
+        mRootLayerTreeId.value());
       mCompositorWidgetDelegate = manager->GetCompositorWidgetDelegate();
       mLayerManager = manager;
     }

--- a/widget/nsBaseWidget.h
+++ b/widget/nsBaseWidget.h
@@ -643,6 +643,8 @@ protected:
 
   void FreeShutdownObserver();
 
+  uint64_t RootLayerTreeId();
+
   nsIWidgetListener* mWidgetListener;
   nsIWidgetListener* mAttachedWidgetListener;
   nsIWidgetListener* mPreviouslyAttachedWidgetListener;
@@ -650,6 +652,7 @@ protected:
   RefPtr<CompositorSession> mCompositorSession;
   RefPtr<CompositorBridgeChild> mCompositorBridgeChild;
   RefPtr<mozilla::CompositorVsyncDispatcher> mCompositorVsyncDispatcher;
+  mozilla::Maybe<uint64_t> mRootLayerTreeId;
   RefPtr<IAPZCTreeManager> mAPZC;
   RefPtr<GeckoContentController> mRootContentController;
   RefPtr<APZEventState> mAPZEventState;


### PR DESCRIPTION
When APZ is hooked up and enabled (future patches) this allows APZ to request composites when an async scroll offset changes.
