### PR TITLE
Fix build failure on linux by Handle reflayers #33

### DIFF
--- a/gfx/layers/LayersLogging.h
+++ b/gfx/layers/LayersLogging.h
@@ -17,6 +17,8 @@
 #include "nsRegion.h"                   // for nsRegion, nsIntRegion
 #include "nscore.h"                     // for nsACString, etc
 
+#include <inttypes.h>
+
 namespace mozilla {
 namespace gfx {
 template <class units, class F> struct RectTyped;


### PR DESCRIPTION
Handle reflayers #33 caused build failure on linux with the following log.
> >  0:03.58 /home/sotaro/quantum_src_2/gecko-dev/gfx/layers/wr/WebrenderContainerLayer.cpp:38:62: error: expected ‘)’ before ‘PRIu64’

It means we need to include inttypes.h before using ‘PRIu64’.