### PR TITLE
Don't export WebrenderLayerManager twice

### DIFF
--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -86,7 +86,7 @@
 #endif
 
 #include "LayerScope.h"
-#include "WebrenderLayerManager.h"
+#include "mozilla/layers/WebrenderLayerManager.h"
 
 namespace mozilla {
 

--- a/gfx/layers/moz.build
+++ b/gfx/layers/moz.build
@@ -44,7 +44,6 @@ EXPORTS += [
     'protobuf/LayerScopePacket.pb.h',
     'ReadbackLayer.h',
     'TiledLayerBuffer.h',
-    'wr/WebrenderLayerManager.h',
 ]
 
 if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'windows':

--- a/gfx/layers/wr/WebrenderContainerLayer.cpp
+++ b/gfx/layers/wr/WebrenderContainerLayer.cpp
@@ -4,6 +4,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "WebrenderContainerLayer.h"
+
+#include <inttypes.h>
 #include "LayersLogging.h"
 
 namespace mozilla {

--- a/widget/nsBaseWidget.cpp
+++ b/widget/nsBaseWidget.cpp
@@ -76,7 +76,7 @@
 #include "gfxConfig.h"
 #include "mozilla/layers/CompositorSession.h"
 #include "VRManagerChild.h"
-#include "WebrenderLayerManager.h"
+#include "mozilla/layers/WebrenderLayerManager.h"
 
 #ifdef DEBUG
 #include "nsIObserver.h"


### PR DESCRIPTION
It's exported once in the top-level include namespace and once into mozilla/layers. This seems unnecessary.