### PR TITLE
Rip out most of the APZ-specific code.

### DIFF
--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -86,7 +86,6 @@
 #endif
 
 #include "LayerScope.h"
-#include "mozilla/layers/WebrenderLayerManager.h"
 
 namespace mozilla {
 
@@ -195,14 +194,6 @@ CompositorBridgeParent::LayerTreeState::~LayerTreeState()
 typedef map<uint64_t, CompositorBridgeParent::LayerTreeState> LayerTreeMap;
 LayerTreeMap sIndirectLayerTrees;
 static StaticAutoPtr<mozilla::Monitor> sIndirectLayerTreesLock;
-
-/* static */
-void
-CompositorBridgeParent::SetWRLayerManager(uint64_t aLayersId,
-                                          WebRenderLayerManager* aLayerManager)
-{
-  sIndirectLayerTrees[aLayersId].mWRManager = aLayerManager;
-}
 
 static void EnsureLayerTreeMapReady()
 {
@@ -2184,9 +2175,6 @@ private:
 CompositorController*
 CompositorBridgeParent::LayerTreeState::GetCompositorController() const
 {
-  if (mWRManager) {
-    return mWRManager;
-  }
   return mParent;
 }
 

--- a/gfx/layers/ipc/CompositorBridgeParent.h
+++ b/gfx/layers/ipc/CompositorBridgeParent.h
@@ -69,7 +69,6 @@ class PAPZParent;
 class CrossProcessCompositorBridgeParent;
 class CompositorThreadHolder;
 class InProcessCompositorSession;
-class WebRenderLayerManager;
 
 struct ScopedLayerTreeRegistration
 {
@@ -249,9 +248,6 @@ public:
                                   const TimeDuration& aVsyncRate,
                                   bool aUseExternalSurfaceSize,
                                   const gfx::IntSize& aSurfaceSize);
-
-  static void SetWRLayerManager(uint64_t aLayersId,
-                                WebRenderLayerManager* aLayerManager);
 
   // Must only be called by CompositorBridgeChild. After invoking this, the
   // IPC channel is active and RecvWillStop/ActorDestroy must be called to
@@ -443,7 +439,6 @@ public:
     APZCTreeManagerParent* mApzcTreeManagerParent;
     CompositorBridgeParent* mParent;
     LayerManagerComposite* mLayerManager;
-    WebRenderLayerManager* mWRManager;
     // Pointer to the CrossProcessCompositorBridgeParent. Used by APZCs to share
     // their FrameMetrics with the corresponding child process that holds
     // the PCompositorBridgeChild

--- a/gfx/layers/wr/WebrenderLayerManager.cpp
+++ b/gfx/layers/wr/WebrenderLayerManager.cpp
@@ -11,7 +11,6 @@
 #include "LayersLogging.h"
 #include "mozilla/layers/APZCTreeManager.h"
 #include "mozilla/layers/AsyncCompositionManager.h"
-#include "mozilla/layers/CompositorBridgeParent.h"
 #include "mozilla/widget/CompositorWidget.h"
 #include "mozilla/widget/PlatformWidgetTypes.h"
 #include "nsThreadUtils.h"
@@ -128,32 +127,22 @@ WRScrollFrameStackingContextGenerator::~WRScrollFrameStackingContextGenerator()
 
 
 WebRenderLayerManager::WebRenderLayerManager(nsIWidget* aWidget,
-                                             uint64_t aLayersId,
-                                             APZCTreeManager* aAPZC)
+                                             uint64_t aLayersId)
   : mWRState(nullptr)
-  , mLayersId(aLayersId)
-  , mAPZC(aAPZC)
-  , mIsFirstPaint(false)
 {
   CompositorWidgetInitData initData;
   aWidget->GetCompositorWidgetInitData(&initData);
   mWidget = CompositorWidget::CreateLocal(initData, aWidget);
   mGLContext = GLContextProvider::CreateForWindow(aWidget, true);
 
-  CompositorBridgeParent::SetWRLayerManager(aLayersId, this);
-
   LayoutDeviceIntSize size = mWidget->GetClientSize();
   mGLContext->MakeCurrent();
-  mWRState = wr_create(size.width, size.height, mLayersId);
+  mWRState = wr_create(size.width, size.height, aLayersId);
 }
 
 void
 WebRenderLayerManager::Destroy()
 {
-  if (mAPZC) {
-    mAPZC->ClearTree();
-    mAPZC = nullptr;
-  }
   DiscardImages();
 }
 
@@ -197,10 +186,6 @@ WebRenderLayerManager::EndTransaction(DrawPaintedLayerCallback aCallback,
                                       void* aCallbackData,
                                       EndTransactionFlags aFlags)
 {
-  if (mAPZC) {
-    mAPZC->UpdateHitTestingTree(mLayersId, GetRoot(), mIsFirstPaint, mLayersId, 0);
-  }
-
   DiscardImages();
 
   mPaintedLayerCallback = aCallback;
@@ -217,7 +202,6 @@ WebRenderLayerManager::EndTransaction(DrawPaintedLayerCallback aCallback,
   wr_dp_begin(mWRState, size.width, size.height);
 
   WebRenderLayer::ToWebRenderLayer(mRoot)->RenderLayer(mWRState);
-  ApplyAPZOffsets();
   mGLContext->MakeCurrent();
 
   printf("WR Ending\n");
@@ -227,48 +211,6 @@ WebRenderLayerManager::EndTransaction(DrawPaintedLayerCallback aCallback,
 
   // Since we don't do repeat transactions right now, just set the time
   mAnimationReadyTime = TimeStamp::Now();
-}
-
-void
-WebRenderLayerManager::ApplyAPZOffsets()
-{
-  // This will probably set the same scroll offset multiple times because
-  // multiple layers will have the same scrollIds. TODO: We should just keep
-  // a list with unique ScrollMetadatas somewhere.
-  ForEachNode<ForwardIterator>(mRoot.get(), [this](Layer* aLayer) {
-    for (size_t i = 0; i < aLayer->GetScrollMetadataCount(); i++) {
-      AsyncPanZoomController* apzc = aLayer->GetAsyncPanZoomController(i);
-      if (apzc) {
-        ParentLayerPoint offset = apzc->GetCurrentAsyncTransform(AsyncPanZoomController::RESPECT_FORCE_DISABLE).mTranslation;
-        wr_set_async_scroll(mWRState, apzc->GetGuid().mScrollId, offset.x, offset.y);
-        if (gfxPrefs::LayersDump()) {
-          printf("Setting async scroll %s for guid %s\n",
-            Stringify(offset).c_str(), Stringify(apzc->GetGuid()).c_str());
-        }
-      }
-    }
-  });
-}
-
-void
-WebRenderLayerManager::Composite()
-{
-  if (!mWRState) {
-    return;
-  }
-  printf("WR Compositing\n");
-
-  ApplyAPZOffsets();
-
-  mGLContext->MakeCurrent();
-  wr_composite(mWRState);
-  mGLContext->SwapBuffers();
-}
-
-void
-WebRenderLayerManager::ScheduleRenderOnCompositorThread()
-{
-  NS_DispatchToMainThread(NewRunnableMethod(this, &WebRenderLayerManager::Composite));
 }
 
 void

--- a/gfx/layers/wr/WebrenderLayerManager.h
+++ b/gfx/layers/wr/WebrenderLayerManager.h
@@ -74,12 +74,11 @@ private:
   WebRenderLayer* mLayer;
 };
 
-class WebRenderLayerManager final : public LayerManager, public CompositorController
+class WebRenderLayerManager final : public LayerManager
 {
 public:
   explicit WebRenderLayerManager(nsIWidget* aWidget,
-                                 uint64_t aLayersId,
-                                 APZCTreeManager* aAPZC);
+                                 uint64_t aLayersId);
 
   virtual void Destroy() override;
 
@@ -98,7 +97,6 @@ public:
   virtual void EndTransaction(DrawPaintedLayerCallback aCallback,
                               void* aCallbackData,
                               EndTransactionFlags aFlags = END_DEFAULT) override;
-  virtual void Composite() override;
 
   virtual LayersBackend GetBackendType() override { return LayersBackend::LAYERS_WR; }
   virtual void GetBackendName(nsAString& name) override { name.AssignLiteral("WebRender"); }
@@ -129,17 +127,6 @@ public:
   void AddImageKeyForDiscard(WRImageKey);
   void DiscardImages();
 
-  // APZ stuff
-  void SetIsFirstPaint() override { mIsFirstPaint = true; }
-  void ApplyAPZOffsets();
-
-  // CompositorController
-  NS_IMETHOD_(MozExternalRefCountType) AddRef() override { return LayerManager::AddRef(); }
-  NS_IMETHOD_(MozExternalRefCountType) Release() override { return LayerManager::Release(); }
-  void ScheduleRenderOnCompositorThread() override;
-  void ScheduleHideAllPluginWindows() override {}
-  void ScheduleShowAllPluginWindows() override {}
-
 private:
   RefPtr<widget::CompositorWidget> mWidget;
   RefPtr<gl::GLContext> mGLContext;
@@ -150,11 +137,6 @@ private:
    * while rendering */
   DrawPaintedLayerCallback mPaintedLayerCallback;
   void *mPaintedLayerCallbackData;
-
-  // APZ stuff
-  uint64_t mLayersId;
-  RefPtr<APZCTreeManager> mAPZC;
-  bool mIsFirstPaint;
 };
 
 } // namespace layers

--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -2392,11 +2392,11 @@ gfxPlatform::AsyncPanZoomEnabled()
   // Firefox on Android) we only want to use APZ when E10S is enabled. If
   // we ever get input events off the main thread we can consider relaxing
   // this requirement.
-  // For webrender hacking we have a special pref to allow APZ even without e10s
-  if (gfxPrefs::APZAllowWithoutE10S()) {
-    return true;
-  }
   if (!BrowserTabsRemoteAutostart()) {
+    return false;
+  }
+  // For webrender hacking we have a special pref to disable APZ even with e10s
+  if (!gfxPrefs::APZAllowWithWebRender()) {
     return false;
   }
 #endif

--- a/gfx/thebes/gfxPrefs.h
+++ b/gfx/thebes/gfxPrefs.h
@@ -253,7 +253,7 @@ private:
   // The apz prefs are explained in AsyncPanZoomController.cpp
   DECL_GFX_PREF(Live, "apz.allow_checkerboarding",             APZAllowCheckerboarding, bool, true);
   DECL_GFX_PREF(Live, "apz.allow_immediate_handoff",           APZAllowImmediateHandoff, bool, true);
-  DECL_GFX_PREF(Once, "apz.allow_without_e10s",                APZAllowWithoutE10S, bool, false);
+  DECL_GFX_PREF(Once, "apz.allow_with_webrender",              APZAllowWithWebRender, bool, false);
   DECL_GFX_PREF(Live, "apz.allow_zooming",                     APZAllowZooming, bool, false);
   DECL_GFX_PREF(Live, "apz.axis_lock.breakout_angle",          APZAxisBreakoutAngle, float, float(M_PI / 8.0) /* 22.5 degrees */);
   DECL_GFX_PREF(Live, "apz.axis_lock.breakout_threshold",      APZAxisBreakoutThreshold, float, 1.0f / 32.0f);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -617,7 +617,7 @@ pref("layout.event-regions.enabled", false);
 // gfx/layers/apz/src/AsyncPanZoomController.cpp.
 pref("apz.allow_checkerboarding", true);
 pref("apz.allow_immediate_handoff", true);
-pref("apz.allow_without_e10s", false);
+pref("apz.allow_with_webrender", false);
 pref("apz.allow_zooming", false);
 
 // Whether to lock touch scrolling to one axis at a time

--- a/widget/nsBaseWidget.h
+++ b/widget/nsBaseWidget.h
@@ -644,8 +644,6 @@ protected:
 
   void FreeShutdownObserver();
 
-  uint64_t RootLayerTreeId();
-
   nsIWidgetListener* mWidgetListener;
   nsIWidgetListener* mAttachedWidgetListener;
   nsIWidgetListener* mPreviouslyAttachedWidgetListener;
@@ -653,7 +651,6 @@ protected:
   RefPtr<CompositorSession> mCompositorSession;
   RefPtr<CompositorBridgeChild> mCompositorBridgeChild;
   RefPtr<mozilla::CompositorVsyncDispatcher> mCompositorVsyncDispatcher;
-  mozilla::Maybe<uint64_t> mRootLayerTreeId;
   RefPtr<IAPZCTreeManager> mAPZC;
   RefPtr<GeckoContentController> mRootContentController;
   RefPtr<APZEventState> mAPZEventState;


### PR DESCRIPTION
This code is not compatible with WebRenderLayerManager being on the content
side in a e10s scenario. Even if we end up going with "option 3" where
WebRenderLayerManager remains in the compositor side, this is kind of hacky
and can be redone better later.