### PR TITLE
Remove unused changes to reduce diff to mozilla-central

### DIFF
--- a/gfx/layers/apz/util/APZCCallbackHelper.cpp
+++ b/gfx/layers/apz/util/APZCCallbackHelper.cpp
@@ -666,19 +666,11 @@ PrepareForSetTargetAPZCNotification(nsIWidget* aWidget,
 }
 
 static void
-SendLayersDependentApzcTargetConfirmation(nsIWidget* aWidget,
-                                          nsIPresShell* aShell,
-                                          uint64_t aInputBlockId,
+SendLayersDependentApzcTargetConfirmation(nsIPresShell* aShell, uint64_t aInputBlockId,
                                           const nsTArray<ScrollableLayerGuid>& aTargets)
 {
   LayerManager* lm = aShell->GetLayerManager();
   if (!lm) {
-    return;
-  }
-
-  if (!lm->AsShadowForwarder()) {
-    // lm is a WebRenderLayerManager
-    aWidget->SetConfirmedTargetAPZC(aInputBlockId, aTargets);
     return;
   }
 
@@ -692,12 +684,10 @@ SendLayersDependentApzcTargetConfirmation(nsIWidget* aWidget,
 
 class DisplayportSetListener : public nsAPostRefreshObserver {
 public:
-  DisplayportSetListener(nsIWidget* aWidget,
-                         nsIPresShell* aPresShell,
+  DisplayportSetListener(nsIPresShell* aPresShell,
                          const uint64_t& aInputBlockId,
                          const nsTArray<ScrollableLayerGuid>& aTargets)
-    : mWidget(aWidget)
-    , mPresShell(aPresShell)
+    : mPresShell(aPresShell)
     , mInputBlockId(aInputBlockId)
     , mTargets(aTargets)
   {
@@ -714,7 +704,7 @@ public:
     }
 
     APZCCH_LOG("Got refresh, sending target APZCs for input block %" PRIu64 "\n", mInputBlockId);
-    SendLayersDependentApzcTargetConfirmation(mWidget, mPresShell, mInputBlockId, Move(mTargets));
+    SendLayersDependentApzcTargetConfirmation(mPresShell, mInputBlockId, Move(mTargets));
 
     if (!mPresShell->RemovePostRefreshObserver(this)) {
       MOZ_ASSERT_UNREACHABLE("Unable to unregister post-refresh observer! Leaking it instead of leaving garbage registered");
@@ -727,7 +717,6 @@ public:
   }
 
 private:
-  RefPtr<nsIWidget> mWidget;
   RefPtr<nsIPresShell> mPresShell;
   uint64_t mInputBlockId;
   nsTArray<ScrollableLayerGuid> mTargets;
@@ -746,7 +735,7 @@ SendSetTargetAPZCNotificationHelper(nsIWidget* aWidget,
   if (waitForRefresh) {
     APZCCH_LOG("At least one target got a new displayport, need to wait for refresh\n");
     waitForRefresh = aShell->AddPostRefreshObserver(
-      new DisplayportSetListener(aWidget, aShell, aInputBlockId, Move(aTargets)));
+      new DisplayportSetListener(aShell, aInputBlockId, Move(aTargets)));
   }
   if (!waitForRefresh) {
     APZCCH_LOG("Sending target APZCs for input block %" PRIu64 "\n", aInputBlockId);

--- a/gfx/layers/ipc/CompositorBridgeParent.cpp
+++ b/gfx/layers/ipc/CompositorBridgeParent.cpp
@@ -192,7 +192,7 @@ CompositorBridgeParent::LayerTreeState::~LayerTreeState()
 }
 
 typedef map<uint64_t, CompositorBridgeParent::LayerTreeState> LayerTreeMap;
-LayerTreeMap sIndirectLayerTrees;
+static LayerTreeMap sIndirectLayerTrees;
 static StaticAutoPtr<mozilla::Monitor> sIndirectLayerTreesLock;
 
 static void EnsureLayerTreeMapReady()
@@ -1883,13 +1883,9 @@ CompositorBridgeParent::SetControllerForLayerTree(uint64_t aLayersId,
 {
   // This ref is adopted by UpdateControllerForLayersId().
   aController->AddRef();
-  if (CompositorLoop()) {
-    CompositorLoop()->PostTask(NewRunnableFunction(&UpdateControllerForLayersId,
-                                                   aLayersId,
-                                                   aController));
-  } else {
-    UpdateControllerForLayersId(aLayersId, aController);
-  }
+  CompositorLoop()->PostTask(NewRunnableFunction(&UpdateControllerForLayersId,
+                                                 aLayersId,
+                                                 aController));
 }
 
 /*static*/ already_AddRefed<APZCTreeManager>

--- a/gfx/layers/opengl/CompositorOGL.cpp
+++ b/gfx/layers/opengl/CompositorOGL.cpp
@@ -50,7 +50,6 @@
 
 #include "GeckoProfiler.h"
 
-mozilla::gl::GLContext* gGLContext;
 namespace mozilla {
 
 using namespace std;
@@ -108,7 +107,6 @@ CompositorOGL::~CompositorOGL()
   Destroy();
 }
 
-
 already_AddRefed<mozilla::gl::GLContext>
 CompositorOGL::CreateContext()
 {
@@ -144,8 +142,6 @@ CompositorOGL::CreateContext()
   if (!context) {
     context = gl::GLContextProvider::CreateForCompositorWidget(mWidget,
                 gfxVars::RequiresAcceleratedGLContextForCompositorOGL());
-    gGLContext = context;
-    printf("Created\n");
   }
 
   if (!context) {

--- a/layout/base/nsDisplayList.cpp
+++ b/layout/base/nsDisplayList.cpp
@@ -11,7 +11,6 @@
  */
 
 #include "nsDisplayList.h"
-#include "webrender.h"
 
 #include <stdint.h>
 #include <algorithm>
@@ -1559,12 +1558,6 @@ MoveListTo(nsDisplayList* aList, nsTArray<nsDisplayItem*>* aElements) {
   }
 }
 
-void nsDisplayList::BuildWRDisplayList(wrstate* wrState) {
-  for (nsDisplayItem* i = GetBottom(); i != nullptr; i = i->GetAbove()) {
-    i->BuildWRDisplayList(wrState);
-  }
-}
-
 nsRect
 nsDisplayList::GetBounds(nsDisplayListBuilder* aBuilder) const {
   nsRect bounds;
@@ -3105,28 +3098,6 @@ static void CheckForBorderItem(nsDisplayItem *aItem, uint32_t& aFlags)
 }
 
 void
-nsDisplayBackgroundImage::BuildWRDisplayList(wrstate* wrState) {
-  nsStyleContext *sc = mFrame->StyleContext();
-
-  bool drawImage;
-  bool drawColor;
-  nscolor bgcolor = nsCSSRendering::DetermineBackgroundColor(mFrame->PresContext(), sc, mFrame, drawImage, drawColor);
-
-  if (!drawColor) {
-    bgcolor = NS_RGB(255, 0, 255);
-  }
-
-  auto color = Color::FromABGR(bgcolor);
-
-  gfxRect bounds =
-    nsLayoutUtils::RectToGfxRect(mBackgroundRect,
-                                 mFrame->PresContext()->AppUnitsPerDevPixel());
-  MOZ_RELEASE_ASSERT(false);
-  //wr_dp_push_rect(wrState, bounds.x, bounds.y, bounds.width, bounds.height, color.r, color.g, color.b, color.a);
-  printf("push %f, %f, %f, %f, %f, %f, %f, %f\n", bounds.x, bounds.y, bounds.width, bounds.height, color.r, color.g, color.b, color.a);
-}
-
-void
 nsDisplayBackgroundImage::Paint(nsDisplayListBuilder* aBuilder,
                                 nsRenderingContext* aCtx) {
   PaintInternal(aBuilder, aCtx, mVisibleRect, &mBounds);
@@ -3541,16 +3512,6 @@ bool
 nsDisplayBackgroundColor::CanApplyOpacity() const
 {
   return true;
-}
-
-void
-nsDisplayBackgroundColor::BuildWRDisplayList(wrstate* wrState) {
-  gfxRect bounds =
-    nsLayoutUtils::RectToGfxRect(mBackgroundRect,
-                                 mFrame->PresContext()->AppUnitsPerDevPixel());
-  MOZ_RELEASE_ASSERT(false);
-  //wr_dp_push_rect(wrState, bounds.x, bounds.y, bounds.width, bounds.height, mColor.r, mColor.g, mColor.b, mColor.a);
-  printf("push %f, %f, %f, %f, %f, %f, %f, %f\n", bounds.x, bounds.y, bounds.width, bounds.height, mColor.r, mColor.g, mColor.b, mColor.a);
 }
 
 void
@@ -4317,9 +4278,6 @@ void
 nsDisplayWrapList::HitTest(nsDisplayListBuilder* aBuilder, const nsRect& aRect,
                            HitTestState* aState, nsTArray<nsIFrame*> *aOutFrames) {
   mList.HitTest(aBuilder, aRect, aState, aOutFrames);
-}
-void nsDisplayWrapList::BuildWRDisplayList(wrstate* wrState) {
-  mList.BuildWRDisplayList(wrState);
 }
 
 nsRect

--- a/layout/base/nsDisplayList.h
+++ b/layout/base/nsDisplayList.h
@@ -49,7 +49,6 @@ class nsIScrollableFrame;
 class nsDisplayLayerEventRegions;
 class nsDisplayScrollInfoLayer;
 class nsCaret;
-struct wrstate;
 
 namespace mozilla {
 class FrameLayerBuilder;
@@ -1359,8 +1358,6 @@ public:
 // Contains all the type integers for each display list item type
 #include "nsDisplayItemTypes.h"
 
-  virtual void BuildWRDisplayList(wrstate* wrState) {}
-
   struct HitTestState {
     explicit HitTestState() : mInPreserves3D(false) {}
 
@@ -2002,8 +1999,6 @@ public:
       aList->mSentinel.mAbove = nullptr;
     }
   }
-
-  void BuildWRDisplayList(wrstate* wrState);
   
   /**
    * Remove an item from the bottom of the list and return it.
@@ -2730,7 +2725,6 @@ public:
                            const nsStyleBackground* aBackgroundStyle);
   virtual ~nsDisplayBackgroundImage();
 
-  virtual void BuildWRDisplayList(wrstate* wrState) override;
   // This will create and append new items for all the layers of the
   // background. Returns whether we appended a themed background.
   // aAllowWillPaintBorderOptimization should usually be left at true, unless
@@ -2913,7 +2907,6 @@ public:
     , mColor(Color::FromABGR(aColor))
   { }
 
-  virtual void BuildWRDisplayList(wrstate* wrState) override;
   virtual void Paint(nsDisplayListBuilder* aBuilder, nsRenderingContext* aCtx) override;
 
   virtual nsRegion GetOpaqueRegion(nsDisplayListBuilder* aBuilder,
@@ -3280,7 +3273,6 @@ public:
     mBaseVisibleRect = mVisibleRect;
   }
   virtual ~nsDisplayWrapList();
-  void BuildWRDisplayList(wrstate* wrState) override;
   /**
    * Call this if the wrapped list is changed.
    */

--- a/layout/base/nsLayoutUtils.cpp
+++ b/layout/base/nsLayoutUtils.cpp
@@ -5,6 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "nsLayoutUtils.h"
+
 #include "mozilla/ArrayUtils.h"
 #include "mozilla/BasicEvents.h"
 #include "mozilla/ClearOnShutdown.h"
@@ -115,7 +116,6 @@
 #include "mozilla/StyleSetHandle.h"
 #include "mozilla/StyleSetHandleInlines.h"
 #include "RegionBuilder.h"
-#include "webrender.h"
 
 #ifdef MOZ_XUL
 #include "nsXULPopupManager.h"
@@ -3675,9 +3675,6 @@ nsLayoutUtils::PaintFrame(nsRenderingContext* aRenderingContext, nsIFrame* aFram
     printf_stderr("Painted %u pixels in %fms (%u in the last 1000ms)\n",
         pixelCount, rasterizeTime, paintedInLastSecond);
   }
-
-  // BENWA
-  // list.BuildWRDisplayList();
 
   if (consoleNeedsDisplayList || profilerNeedsDisplayList) {
     *ss << "Painting --- after optimization:\n";

--- a/layout/base/nsPresShell.cpp
+++ b/layout/base/nsPresShell.cpp
@@ -17,9 +17,7 @@
  */
 
 /* a presentation of a document, part 2 */
-#include "mozilla/layers/LayerManagerComposite.h"
-#include "GLContext.h"                  // for GLContext
-#include "mozilla/layers/CompositorOGL.h"
+
 #include "mozilla/Logging.h"
 
 #include "mozilla/ArrayUtils.h"
@@ -220,7 +218,6 @@ using namespace mozilla::tasktracer;
 #define RELATIVE_SCALEFACTOR 0.0925f
 
 using namespace mozilla;
-using namespace mozilla::gl;
 using namespace mozilla::css;
 using namespace mozilla::dom;
 using namespace mozilla::gfx;
@@ -6292,7 +6289,6 @@ PresShell::Paint(nsView*        aViewToPaint,
   bool shouldInvalidate = layerManager->NeedsWidgetInvalidation();
 
   nsAutoNotifyDidPaint notifyDidPaint(this, aFlags);
-
 
   // Whether or not we should set first paint when painting is
   // suppressed is debatable. For now we'll do it because

--- a/widget/nsBaseWidget.cpp
+++ b/widget/nsBaseWidget.cpp
@@ -58,7 +58,6 @@
 #include "mozilla/layers/ChromeProcessController.h"
 #include "mozilla/layers/InputAPZContext.h"
 #include "mozilla/layers/APZCCallbackHelper.h"
-#include "mozilla/layers/APZCTreeManager.h"
 #include "mozilla/layers/WebrenderLayerManager.h"
 #include "mozilla/dom/ContentChild.h"
 #include "mozilla/dom/TabParent.h"


### PR DESCRIPTION
Reducing the diff to m-c will make it easier to focus on the changes we actually need to clean up and port to m-c.