### PR TITLE
Fix Firefox builds without WR

### DIFF
--- a/gfx/gl/GLContextProviderCGL.mm
+++ b/gfx/gl/GLContextProviderCGL.mm
@@ -194,8 +194,10 @@ static const NSOpenGLPixelFormatAttribute kAttribs_doubleBuffered_accel[] = {
     NSOpenGLPFAAccelerated,
     NSOpenGLPFAAllowOfflineRenderers,
     NSOpenGLPFADoubleBuffer,
+#ifdef MOZ_ENABLE_WEBRENDER
     NSOpenGLPFAOpenGLProfile,
     NSOpenGLProfileVersion3_2Core,
+#endif
     0
 };
 

--- a/gfx/gl/GLContextProviderGLX.cpp
+++ b/gfx/gl/GLContextProviderGLX.cpp
@@ -1133,8 +1133,12 @@ CreateForWidget(Display* aXDisplay, Window aXWindow, bool aForceAccelerated)
     RefPtr<GLContextGLX> gl = GLContextGLX::CreateGLContext(CreateContextFlags::NONE,
                                                             caps, shareContext, false,
                                                             aXDisplay, aXWindow, config,
+#ifdef MOZ_ENABLE_WEBRENDER
                                                             //TODO: we might want to pass an additional bool to select GL core/compat
                                                             false, nullptr, ContextProfile::OpenGLCore); //WR: required GL 3.2+
+#else
+                                                            false);
+#endif
     return gl.forget();
 }
 


### PR DESCRIPTION
For some reason I just get a black window if I run the current Gecko-WebRenderer branch without --enable-webrender. The attached patch seems to fix it.