### PR TITLE
Basic support for reftests with webrender

### DIFF
--- a/gfx/layers/ipc/PWebRenderBridge.ipdl
+++ b/gfx/layers/ipc/PWebRenderBridge.ipdl
@@ -38,6 +38,8 @@ parent:
   sync DPBegin(uint32_t aWidth, uint32_t aHeight)
     returns (bool aOutSuccess);
   sync DPEnd();
+  sync DPMakeSnapshot(uint32_t aWidth, uint32_t aHeight)
+    returns (uint8_t[] aOutImageSnapshot, int aOutLength);
   sync DPPushRect(WRRect aBounds, WRRect aClip, float r, float g, float b, float a);
   sync DPPushImage(WRRect aBounds, WRRect aClip, MaybeImageMask aMask, WRImageKey aKey);
   sync DPPushIframe(WRRect aBounds, WRRect aClip, uint64_t aLayersId);

--- a/gfx/layers/wr/WebRenderBridgeParent.h
+++ b/gfx/layers/wr/WebRenderBridgeParent.h
@@ -60,6 +60,10 @@ public:
                    const uint32_t& aHeight,
                    bool* aOutSuccess) override;
   bool RecvDPEnd() override;
+  bool RecvDPMakeSnapshot(const uint32_t& aWidth,
+                          const uint32_t& aHeight,
+                          InfallibleTArray<uint8_t>* aOutImageSnapshot,
+                          int* aOutLength) override;
   bool RecvDPPushRect(const WRRect& aBounds,
                       const WRRect& aClip,
                       const float& r, const float& g, const float& b, const float& a) override;

--- a/gfx/layers/wr/WebrenderLayerManager.h
+++ b/gfx/layers/wr/WebrenderLayerManager.h
@@ -127,6 +127,24 @@ private:
   nsIWidget* MOZ_NON_OWNING_REF mWidget;
   std::vector<WRImageKey> mImageKeys;
 
+  // When we're doing a transaction in order to draw to a non-default
+  // target, the layers transaction is only performed in order to send
+  // a PLayers:Update.  We save the original non-default target to
+  // mShadowTarget, and then perform the transaction using
+  // mDummyTarget as the render target.  After the transaction ends,
+  // we send a message to our remote side to capture the actual pixels
+  // being drawn to the default target, and then copy those pixels
+  // back to mShadowTarget.
+  RefPtr<gfxContext> mShadowTarget;
+
+  /**
+   * Take a snapshot of the parent context, and copy
+   * it into mShadowTarget.
+   */
+  void MakeSnapshotIfRequired(nsTArray<uint8_t>& aSnapshot,
+                              int& aLength,
+                              LayoutDeviceIntSize aSize);
+
   /* PaintedLayer callbacks; valid at the end of a transaciton,
    * while rendering */
   DrawPaintedLayerCallback mPaintedLayerCallback;

--- a/gfx/webrender/webrender.h
+++ b/gfx/webrender/webrender.h
@@ -92,6 +92,10 @@ wr_dp_end(wrwindowstate* wrWindow, wrstate* wrState)
 WR_FUNC;
 
 WR_INLINE void
+wr_sync_paint(wrwindowstate* wrWindow, wrstate* wrState)
+WR_FUNC;
+
+WR_INLINE void
 wr_composite(wrwindowstate* wrWindow)
 WR_FUNC;
 


### PR DESCRIPTION
Hooks up into EndTransactionWithTarget and sends an IPDL request to finally have a glReadPixels in Webrender. It then copies this data into the requested target.

Depends on WR push https://github.com/servo/webrender/pull/560

I think I can clean this up a bit more. I was going to look into using the epoch data, which we currently send as (0) every frame. This is how servo does reftests. It just waits for the proper epoch to finish rendering. 

The current jist is that we have some synchronization work to ensure that (1) The current paint sent to the render thread is finished before snapshotting and (2) Paints sent to the render thread before requesting a snapshot are also finished. 

While not complete, I'd like to land this once the WR PR lands so I don't have to rebase everyday :). Thanks!