### PR TITLE
Add stubbed WebrenderCompositorOGL

### DIFF
--- a/gfx/layers/Compositor.h
+++ b/gfx/layers/Compositor.h
@@ -577,7 +577,7 @@ public:
   // A stale Compositor has no CompositorBridgeParent; it will not process
   // frames and should not be used.
   void SetInvalid();
-  bool IsValid() const;
+  virtual bool IsValid() const;
   CompositorBridgeParent* GetCompositorBridgeParent() const {
     return mParent;
   }

--- a/gfx/layers/moz.build
+++ b/gfx/layers/moz.build
@@ -203,6 +203,7 @@ EXPORTS.mozilla.layers += [
     'TransactionIdAllocator.h',
     'wr/WebRenderBridgeChild.h',
     'wr/WebRenderBridgeParent.h',
+    'wr/WebRenderCompositorOGL.h',
     'wr/WebrenderLayerManager.h',
     'wr/WebRenderTypes.h',
 ]
@@ -378,6 +379,7 @@ UNIFIED_SOURCES += [
     'wr/WebRenderBridgeParent.cpp',
     'wr/WebrenderCanvasLayer.cpp',
     'wr/WebrenderColorLayer.cpp',
+    'wr/WebRenderCompositorOGL.cpp',
     'wr/WebrenderContainerLayer.cpp',
     'wr/WebrenderImageLayer.cpp',
     'wr/WebrenderLayerManager.cpp',

--- a/gfx/layers/wr/WebRenderBridgeParent.cpp
+++ b/gfx/layers/wr/WebRenderBridgeParent.cpp
@@ -8,6 +8,7 @@
 
 #include "GLContext.h"
 #include "GLContextProvider.h"
+#include "mozilla/layers/Compositor.h"
 #include "mozilla/widget/CompositorWidget.h"
 
 namespace mozilla {
@@ -16,14 +17,17 @@ namespace layers {
 WebRenderBridgeParent::WebRenderBridgeParent(const uint64_t& aPipelineId,
                                              widget::CompositorWidget* aWidget,
                                              gl::GLContext* aGlContext,
-                                             wrwindowstate* aWrWindowState)
+                                             wrwindowstate* aWrWindowState,
+                                             layers::Compositor* aCompositor)
   : mPipelineId(aPipelineId)
   , mWidget(aWidget)
   , mWRState(nullptr)
   , mGLContext(aGlContext)
   , mWRWindowState(aWrWindowState)
+  , mCompositor(aCompositor)
 {
   MOZ_ASSERT(mGLContext);
+  MOZ_ASSERT(mCompositor);
   if (!mWRWindowState) {
     // mWRWindowState should only be null for the root WRBP of a layers tree,
     // i.e. the one created by the CompositorBridgeParent as opposed to the
@@ -50,8 +54,12 @@ bool
 WebRenderBridgeParent::RecvDestroy()
 {
   MOZ_ASSERT(mWRState);
+  MOZ_ASSERT(mCompositor);
   wr_destroy(mWRState);
   mWRState = nullptr;
+  if (mWidget) {
+    mCompositor->Destroy();
+  }
   return true;
 }
 

--- a/gfx/layers/wr/WebRenderBridgeParent.h
+++ b/gfx/layers/wr/WebRenderBridgeParent.h
@@ -23,6 +23,8 @@ class CompositorWidget;
 
 namespace layers {
 
+class Compositor;
+
 class WebRenderBridgeParent final : public PWebRenderBridgeParent
 {
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(WebRenderBridgeParent)
@@ -31,10 +33,12 @@ public:
   WebRenderBridgeParent(const uint64_t& aPipelineId,
                         widget::CompositorWidget* aWidget,
                         gl::GLContext* aGlContext,
-                        wrwindowstate* aWrWindowState);
+                        wrwindowstate* aWrWindowState,
+                        layers::Compositor* aCompositor);
   uint64_t PipelineId() { return mPipelineId; }
   gl::GLContext* GLContext() { return mGLContext.get(); }
   wrwindowstate* WindowState() { return mWRWindowState; }
+  layers::Compositor* Compositor() { return mCompositor.get(); }
 
   bool RecvCreate(const uint32_t& aWidth,
                   const uint32_t& aHeight) override;
@@ -83,6 +87,7 @@ private:
   wrstate* mWRState;
   RefPtr<gl::GLContext> mGLContext;
   wrwindowstate* mWRWindowState;
+  RefPtr<layers::Compositor> mCompositor;
   std::vector<WRImageKey> mKeysToDelete;
 };
 

--- a/gfx/layers/wr/WebRenderCompositorOGL.cpp
+++ b/gfx/layers/wr/WebRenderCompositorOGL.cpp
@@ -1,0 +1,85 @@
+/* -*- Mode: C++; tab-width: 20; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "WebRenderCompositorOGL.h"
+
+#include "GLContext.h"                  // for GLContext
+#include "GLUploadHelpers.h"
+#include "mozilla/layers/TextureHost.h"  // for TextureSource, etc
+#include "mozilla/layers/TextureHostOGL.h"  // for TextureSourceOGL, etc
+
+namespace mozilla {
+
+using namespace gfx;
+
+namespace layers {
+
+using namespace mozilla::gl;
+
+WebRenderCompositorOGL::WebRenderCompositorOGL(GLContext* aGLContext)
+  : Compositor(nullptr, nullptr)
+  , mDestroyed(false)
+{
+  MOZ_COUNT_CTOR(WebRenderCompositorOGL);
+}
+
+WebRenderCompositorOGL::~WebRenderCompositorOGL()
+{
+  MOZ_COUNT_DTOR(WebRenderCompositorOGL);
+  Destroy();
+}
+
+void
+WebRenderCompositorOGL::Destroy()
+{
+  Compositor::Destroy();
+
+  if (!mDestroyed) {
+    mDestroyed = true;
+    mGLContext = nullptr;;
+  }
+}
+
+bool
+WebRenderCompositorOGL::Initialize(nsCString* const out_failureReason)
+{
+  MOZ_ASSERT(mGLContext);
+  return true;
+}
+
+already_AddRefed<DataTextureSource>
+WebRenderCompositorOGL::CreateDataTextureSource(TextureFlags aFlags)
+{
+  return nullptr;
+}
+
+bool
+WebRenderCompositorOGL::SupportsPartialTextureUpdate()
+{
+  return CanUploadSubTextures(mGLContext);
+}
+
+int32_t
+WebRenderCompositorOGL::GetMaxTextureSize() const
+{
+  MOZ_ASSERT(mGLContext);
+  GLint texSize = 0;
+  mGLContext->fGetIntegerv(LOCAL_GL_MAX_TEXTURE_SIZE,
+                            &texSize);
+  MOZ_ASSERT(texSize != 0);
+  return texSize;
+}
+
+void
+WebRenderCompositorOGL::MakeCurrent(MakeCurrentFlags aFlags) {
+  if (mDestroyed) {
+    NS_WARNING("Call on destroyed layer manager");
+    return;
+  }
+  mGLContext->MakeCurrent(aFlags & ForceMakeCurrent);
+}
+
+} // namespace layers
+} // namespace mozilla

--- a/gfx/layers/wr/WebRenderCompositorOGL.h
+++ b/gfx/layers/wr/WebRenderCompositorOGL.h
@@ -1,0 +1,122 @@
+/* -*- Mode: C++; tab-width: 20; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MOZILLA_GFX_WEBRENDERCOMPOSITOROGL_H
+#define MOZILLA_GFX_WEBRENDERCOMPOSITOROGL_H
+
+#include "GLContextTypes.h"             // for GLContext, etc
+#include "GLDefs.h"                     // for GLuint, LOCAL_GL_TEXTURE_2D, etc
+#include "mozilla/layers/Compositor.h"  // for SurfaceInitMode, Compositor, etc
+
+namespace mozilla {
+namespace layers {
+
+class WebRenderCompositorOGL final : public Compositor
+{
+  typedef mozilla::gl::GLContext GLContext;
+
+public:
+  explicit WebRenderCompositorOGL(GLContext* aGLContext);
+
+protected:
+  virtual ~WebRenderCompositorOGL();
+
+public:
+  virtual already_AddRefed<DataTextureSource>
+  CreateDataTextureSource(TextureFlags aFlags = TextureFlags::NO_FLAGS) override;
+
+  virtual bool Initialize(nsCString* const out_failureReason) override;
+
+  virtual void Destroy() override;
+
+  virtual TextureFactoryIdentifier GetTextureFactoryIdentifier() override
+  {
+    TextureFactoryIdentifier result =
+      TextureFactoryIdentifier(LayersBackend::LAYERS_OPENGL,
+                               XRE_GetProcessType(),
+                               GetMaxTextureSize(),
+                               true,
+                               SupportsPartialTextureUpdate());
+    return result;
+  }
+
+  virtual already_AddRefed<CompositingRenderTarget>
+  CreateRenderTarget(const gfx::IntRect &aRect, SurfaceInitMode aInit) override { return nullptr; }
+
+  virtual already_AddRefed<CompositingRenderTarget>
+  CreateRenderTargetFromSource(const gfx::IntRect &aRect,
+                               const CompositingRenderTarget *aSource,
+                               const gfx::IntPoint &aSourcePoint) override { return nullptr; }
+
+  virtual void SetRenderTarget(CompositingRenderTarget *aSurface) override { }
+
+  virtual CompositingRenderTarget* GetCurrentRenderTarget() const override { return nullptr; }
+
+  virtual void DrawQuad(const gfx::Rect& aRect,
+                        const gfx::IntRect& aClipRect,
+                        const EffectChain &aEffectChain,
+                        gfx::Float aOpacity,
+                        const gfx::Matrix4x4& aTransform,
+                        const gfx::Rect& aVisibleRect) { }
+
+  virtual void DrawTriangle(const gfx::TexturedTriangle& aTriangle,
+                            const gfx::IntRect& aClipRect,
+                            const EffectChain& aEffectChain,
+                            gfx::Float aOpacity,
+                            const gfx::Matrix4x4& aTransform,
+                            const gfx::Rect& aVisibleRect) { }
+
+  virtual void ClearRect(const gfx::Rect& aRect) { }
+
+  virtual void BeginFrame(const nsIntRegion& aInvalidRegion,
+                          const gfx::IntRect *aClipRectIn,
+                          const gfx::IntRect& aRenderBounds,
+                          const nsIntRegion& aOpaqueRegion,
+                          gfx::IntRect *aClipRectOut = nullptr,
+                          gfx::IntRect *aRenderBoundsOut = nullptr) override { }
+
+  virtual void EndFrame() override { }
+
+  virtual void EndFrameForExternalComposition(const gfx::Matrix& aTransform) override { }
+
+  virtual bool SupportsPartialTextureUpdate() override;
+
+  virtual bool CanUseCanvasLayerForSize(const gfx::IntSize &aSize) override
+  {
+    if (!mGLContext)
+      return false;
+    int32_t maxSize = GetMaxTextureSize();
+    return aSize <= gfx::IntSize(maxSize, maxSize);
+  }
+
+  virtual int32_t GetMaxTextureSize() const override;
+
+  virtual void SetDestinationSurfaceSize(const gfx::IntSize& aSize) override { }
+  virtual void SetScreenRenderOffset(const ScreenPoint& aOffset) override { }
+
+  virtual void MakeCurrent(MakeCurrentFlags aFlags = 0) override;
+
+#ifdef MOZ_DUMP_PAINTING
+  virtual const char* Name() const override { return "WROGL"; }
+#endif // MOZ_DUMP_PAINTING
+
+  virtual LayersBackend GetBackendType() const override {
+    return LayersBackend::LAYERS_OPENGL;
+  }
+
+  virtual bool IsValid() const override { return true; }
+
+  GLContext* gl() const { return mGLContext; }
+
+private:
+  RefPtr<GLContext> mGLContext;
+
+  bool mDestroyed;
+};
+
+} // namespace layers
+} // namespace mozilla
+
+#endif /* MOZILLA_GFX_WEBRENDERCOMPOSITOROGL_H */


### PR DESCRIPTION
Add stubbed WebrenderCompositorOGL. It is used for video rendering and re-composition scheduling.
   https://bugzilla.mozilla.org/show_bug.cgi?id=1312316